### PR TITLE
Implemented OPC Browser functionality

### DIFF
--- a/connection_test.go
+++ b/connection_test.go
@@ -5,6 +5,25 @@ import (
 	"testing"
 )
 
+func TestOPCBrowser(t *testing.T) {
+	browser, err := CreateBrowser(
+		"Graybox.Simulator",
+		[]string{"localhost"},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if browser.Name != "root" {
+		t.Fatal("structure of browser tree is compromised: root")
+	}
+	if browser.Branches[0].Name != "options" {
+		t.Fatal("structure of browser tree is compromised: options")
+	}
+	if len(browser.Branches[0].Leaves) != 4 {
+		t.Fatal("structure of browser tree is compromised: number of leaves for options")
+	}
+}
+
 func TestNewConnectionNoTags(t *testing.T) {
 	client := NewConnection(
 		"Graybox.Simulator",

--- a/example/browser.go
+++ b/example/browser.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/konimarti/opc"
+)
+
+func main() {
+	progid := "Graybox.Simulator"
+	nodes := []string{"localhost"}
+
+	// create browser and collect all tags on OPC server
+	browser, err := opc.CreateBrowser(progid, nodes)
+	if err != nil {
+		panic(err)
+	}
+
+	// extract subtree
+	subtree := opc.ExtractBranchByName(browser, "textual")
+
+	// print out all the information
+	opc.PrettyPrint(subtree)
+
+	// create opc connection with all tags from subtree
+	conn := opc.NewConnection(
+		progid,
+		nodes,
+		opc.CollectTags(subtree),
+	)
+	defer conn.Close()
+
+	fmt.Println(conn.Read())
+}

--- a/tree.go
+++ b/tree.go
@@ -1,0 +1,65 @@
+package opc
+
+import "fmt"
+
+//Tree creates an OPC browser representation
+type Tree struct {
+	Name     string
+	Parent   *Tree
+	Branches []*Tree
+	Leaves   []Leaf
+}
+
+//Leaf contains the OPC tag and forms part of the Tree struct for the  OPC browser
+type Leaf struct {
+	Name string
+	Tag  string
+}
+
+//ExtractBranchByName return substree with name
+func ExtractBranchByName(tree *Tree, name string) *Tree {
+	if tree.Name == name {
+		return tree
+	}
+	for _, b := range tree.Branches {
+		subtree := ExtractBranchByName(b, name)
+		if subtree != nil {
+			return subtree
+		}
+	}
+	return nil
+}
+
+//CollectTags traverses tree and collects all tags in string slice
+func CollectTags(tree *Tree) []string {
+	collection := []string{}
+	for _, l := range tree.Leaves {
+		collection = append(collection, l.Tag)
+	}
+	for _, b := range tree.Branches {
+		lowerCollection := CollectTags(b)
+		collection = append(collection, lowerCollection...)
+	}
+	return collection
+}
+
+//PrettyPrint prints tree in a nice format
+func PrettyPrint(tree *Tree) {
+	fmt.Println(tree.Name)
+	printSubtree(tree, 1)
+}
+
+// printSubtree is a recursive helper function to traverse the tree
+func printSubtree(tree *Tree, level int) {
+	space := ""
+	for i := 0; i < level; i++ {
+		space += "  "
+	}
+	for _, l := range tree.Leaves {
+		fmt.Println(space, "-", l.Tag)
+	}
+	for _, b := range tree.Branches {
+		fmt.Println(space, "+", b.Name)
+		printSubtree(b, level+1)
+	}
+}

--- a/tree_test.go
+++ b/tree_test.go
@@ -1,0 +1,76 @@
+package opc
+
+import (
+	"testing"
+)
+
+func testingCreateNewTree() *Tree {
+
+	root := Tree{
+		Name:     "root",
+		Parent:   nil,
+		Branches: []*Tree{},
+		Leaves: []Leaf{
+			Leaf{
+				Name: "bandwith",
+				Tag:  "bandwith",
+			},
+		},
+	}
+	options := Tree{
+		Name:     "options",
+		Parent:   &root,
+		Branches: []*Tree{},
+		Leaves: []Leaf{
+			Leaf{
+				Name: "frequency",
+				Tag:  "options.frequency",
+			},
+			Leaf{
+				Name: "amplitute",
+				Tag:  "options.amplitude",
+			},
+		},
+	}
+	numeric := Tree{
+		Name:     "numeric",
+		Parent:   &root,
+		Branches: []*Tree{},
+		Leaves: []Leaf{
+			Leaf{
+				Name: "sin",
+				Tag:  "numeric.sin",
+			},
+			Leaf{
+				Name: "cos",
+				Tag:  "numeric.cos",
+			},
+			Leaf{
+				Name: "tan",
+				Tag:  "numeric.tan",
+			},
+		},
+	}
+
+	root.Branches = append(root.Branches, &options, &numeric)
+	return &root
+}
+
+func TestTreeExtractBranchByName(t *testing.T) {
+	tree := testingCreateNewTree()
+	subtree := ExtractBranchByName(tree, "numeric")
+	if subtree == nil {
+		t.Fatal("subtree not correctly extracted")
+	}
+	if len(CollectTags(subtree)) != 3 {
+		t.Fatal("subtree not correctly extracted")
+	}
+}
+
+func TestTreeCollectTags(t *testing.T) {
+	tree := testingCreateNewTree()
+	collection := CollectTags(tree)
+	if len(collection) != 6 {
+		t.Fatal("not enough tags collected")
+	}
+}


### PR DESCRIPTION
fixes #3 

see example [example/browser.go]

```go
package main

import (
	"github.com/konimarti/opc"
)

func main() {
	browser := opc.CreateBrowser(
		"Graybox.Simulator",
		[]string{"localhost"},
	)
	opc.PrettyPrint(browser)
}
```