### PR TITLE
CLI to list, browse, read and write OPC data

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![GoDoc](https://godoc.org/github.com/konimarti/observer?status.svg)](https://godoc.org/github.com/konimarti/opc)
 [![goreportcard](https://goreportcard.com/badge/github.com/konimarti/observer)](https://goreportcard.com/report/github.com/konimarti/opc)
 
-Read process and automation data in Go from an OPC server for monitoring and data analysis purposes (OPC DA protocol).
+Read and write process and automation data in Go from an OPC server for monitoring and data analysis purposes (OPC DA protocol).
 
 ```go get github.com/konimarti/opc```
 
@@ -85,7 +85,7 @@ map[numeric.sin.int64:-34 numeric.saw.float:88.9]
 
 ## Applications 
 
-### Command-line interface: opc-cli
+### opc-cli
 
 * ```opc-cli``` is a command-line interface to work with OPC servers: list available OPC servers, browse OPC tags on server, and read/write OPC tags.
 * Install it with ```go install github.com/konimarti/opc/cmds/opc-cli```
@@ -93,7 +93,6 @@ map[numeric.sin.int64:-34 numeric.saw.float:88.9]
   - List OPC servers on a specific node: 
     ```
     $ opc-cli.exe list localhost
-
 	Found 3 server(s) on 'localhost':
 	Graybox.Simulator.1
 	INAT TcpIpH1 OPC Server
@@ -103,7 +102,6 @@ map[numeric.sin.int64:-34 numeric.saw.float:88.9]
   - Browse OPC tags (in sub-branch):
     ```
     $ opc-cli.exe browse localhost Graybox.Simulator.1 textual
-
 	textual
 	   - textual.color
 	   - textual.number
@@ -119,7 +117,6 @@ map[numeric.sin.int64:-34 numeric.saw.float:88.9]
   - Read OPC tags:
     ```
     $ opc-cli.exe read localhost Graybox.Simulator.1 options.sinfreq numeric.sin.float
-
 	map[numeric.sin.float:21.096313 options.sinfreq:0.01]
     ```
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,48 @@ with the following output:
 map[numeric.sin.int64:-34 numeric.saw.float:88.9]
 ```
 
-## OPCAPI
+## Applications 
+
+### Command-line interface: opc-cli
+
+* ```opc-cli``` is a command-line interface to work with OPC servers: list available OPC servers, browse OPC tags on server, and read/write OPC tags.
+* Install it with ```go install github.com/konimarti/opc/cmds/opc-cli```
+
+  - List OPC servers on a specific node: 
+    ```
+    $ opc-cli.exe list localhost
+
+	Found 3 server(s) on 'localhost':
+	Graybox.Simulator.1
+	INAT TcpIpH1 OPC Server
+	Prosys.OPC.Simulation
+    ```
+
+  - Browse OPC tags (in sub-branch):
+    ```
+    $ opc-cli.exe browse localhost Graybox.Simulator.1 textual
+
+	textual
+	   - textual.color
+	   - textual.number
+	   - textual.random
+	   - textual.weekday
+    ```
+
+  - Write to OPC tag:
+    ```
+    $ opc-cli.exe write localhost Graybox.Simulator.1 options.sinfreq 0.01
+    ```
+
+  - Read OPC tags:
+    ```
+    $ opc-cli.exe read localhost Graybox.Simulator.1 options.sinfreq numeric.sin.float
+
+	map[numeric.sin.float:21.096313 options.sinfreq:0.01]
+    ```
+
+
+### OPCAPI
 
 * Application to expose OPC tags with a JSON REST API.
 
@@ -125,7 +166,7 @@ map[numeric.sin.int64:-34 numeric.saw.float:88.9]
       {"result": "removed"}
       ```
 
-## OPCFLUX
+### OPCFLUX
 
 * Application to write OPC data directly to InfluxDB.
 

--- a/cmds/opc-cli/main.go
+++ b/cmds/opc-cli/main.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/konimarti/opc"
+	"github.com/spf13/cobra"
+)
+
+func main() {
+	//var server, node string
+
+	var cmdList = &cobra.Command{
+		Use:   "list [node]",
+		Short: "Lists the OPC servers on node.",
+		Long:  ``,
+		Args:  cobra.MinimumNArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			node := args[0]
+			servers_found := opc.NewAutomationObject().GetOPCServers(node)
+			fmt.Printf("Found %d server(s) on '%s':\n", len(servers_found), node)
+			for _, server := range servers_found {
+				fmt.Println(server)
+			}
+		},
+	}
+
+	var rootCmd = &cobra.Command{Use: "opc-cli"}
+	//rootCmd.PersistentFlags().StringVarP(&server, "server", "s", "Graybox.Simulator", "ProgID for OPC Server")
+	//rootCmd.PersistentFlags().StringVarP(&node, "node", "n", "localhost", "Node for OPC Server")
+
+	rootCmd.AddCommand(cmdList)
+	rootCmd.Execute()
+}

--- a/cmds/opc-cli/main.go
+++ b/cmds/opc-cli/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/konimarti/opc"
 	"github.com/spf13/cobra"
@@ -25,10 +26,33 @@ func main() {
 		},
 	}
 
+	var cmdInfo = &cobra.Command{
+		Use:   "info [server] [node]",
+		Short: "Try connect the OPC servers on node and get some info.",
+		Long:  ``,
+		Args:  cobra.MinimumNArgs(2),
+		Run: func(cmd *cobra.Command, args []string) {
+			server := args[0]
+			nodes := []string{args[1]}
+			obj := opc.NewAutomationObject()
+			_, err := obj.TryConnect(server, nodes)
+			if err != nil {
+				fmt.Println(err)
+				os.Exit(1)
+			}
+			if obj.IsConnected() {
+				fmt.Printf("%s on '%v' is up and running.\n", server, nodes[0])
+			} else {
+				fmt.Printf("%s on '%v' is not running.\n", server, nodes[0])
+			}
+
+		},
+	}
+
 	var rootCmd = &cobra.Command{Use: "opc-cli"}
 	//rootCmd.PersistentFlags().StringVarP(&server, "server", "s", "Graybox.Simulator", "ProgID for OPC Server")
 	//rootCmd.PersistentFlags().StringVarP(&node, "node", "n", "localhost", "Node for OPC Server")
 
-	rootCmd.AddCommand(cmdList)
+	rootCmd.AddCommand(cmdList, cmdInfo)
 	rootCmd.Execute()
 }

--- a/cmds/opc-cli/main.go
+++ b/cmds/opc-cli/main.go
@@ -12,7 +12,7 @@ func main() {
 
 	var cmdList = &cobra.Command{
 		Use:   "list [node]",
-		Short: "Lists the OPC servers on node.",
+		Short: "Lists the OPC servers available on a specific node.",
 		Long:  ``,
 		Args:  cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
@@ -26,13 +26,13 @@ func main() {
 	}
 
 	var cmdInfo = &cobra.Command{
-		Use:   "info [server] [node]",
-		Short: "Try connect the OPC servers on node and get some info.",
+		Use:   "info [node] [server]",
+		Short: "Try connect the OPC server on a specific node and check if it is running.",
 		Long:  ``,
 		Args:  cobra.MinimumNArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {
-			server := args[0]
-			nodes := []string{args[1]}
+			nodes := []string{args[0]}
+			server := args[1]
 			obj := opc.NewAutomationObject()
 			_, err := obj.TryConnect(server, nodes)
 			if err != nil {
@@ -48,8 +48,66 @@ func main() {
 		},
 	}
 
+	var cmdBrowse = &cobra.Command{
+		Use:   "browse [node] [server] [branch_name]",
+		Short: "Browse OPC tags. If only sub-branch is requested, use optional branch_name.",
+		Long:  ``,
+		Args:  cobra.MinimumNArgs(2),
+		Run: func(cmd *cobra.Command, args []string) {
+			nodes := []string{args[0]}
+			server := args[1]
+			name := "root"
+			if len(args) > 2 {
+				name = args[2]
+			}
+			tree, err := opc.CreateBrowser(server, nodes)
+			if err != nil {
+				fmt.Println(err)
+				os.Exit(1)
+			}
+			opc.PrettyPrint(opc.ExtractBranchByName(tree, name))
+		},
+	}
+
+	var cmdRead = &cobra.Command{
+		Use:   "read [node] [server] [tags...]",
+		Short: "Read OPC tags.",
+		Long:  ``,
+		Args:  cobra.MinimumNArgs(3),
+		Run: func(cmd *cobra.Command, args []string) {
+			nodes := []string{args[0]}
+			server := args[1]
+			tags := args[2:]
+			conn := opc.NewConnection(
+				server,
+				nodes,
+				tags,
+			)
+			fmt.Println(conn.Read())
+		},
+	}
+
+	var cmdWrite = &cobra.Command{
+		Use:   "write [node] [server] [tag] [value]",
+		Short: "Write value to OPC tag.",
+		Long:  ``,
+		Args:  cobra.MinimumNArgs(4),
+		Run: func(cmd *cobra.Command, args []string) {
+			nodes := []string{args[0]}
+			server := args[1]
+			tag := args[2]
+			value := args[3]
+			conn := opc.NewConnection(
+				server,
+				nodes,
+				[]string{tag},
+			)
+			conn.Write(tag, value)
+		},
+	}
+
 	var rootCmd = &cobra.Command{Use: "opc-cli"}
 
-	rootCmd.AddCommand(cmdList, cmdInfo)
+	rootCmd.AddCommand(cmdList, cmdInfo, cmdBrowse, cmdRead, cmdWrite)
 	rootCmd.Execute()
 }

--- a/cmds/opc-cli/main.go
+++ b/cmds/opc-cli/main.go
@@ -9,7 +9,6 @@ import (
 )
 
 func main() {
-	//var server, node string
 
 	var cmdList = &cobra.Command{
 		Use:   "list [node]",
@@ -50,8 +49,6 @@ func main() {
 	}
 
 	var rootCmd = &cobra.Command{Use: "opc-cli"}
-	//rootCmd.PersistentFlags().StringVarP(&server, "server", "s", "Graybox.Simulator", "ProgID for OPC Server")
-	//rootCmd.PersistentFlags().StringVarP(&node, "node", "n", "localhost", "Node for OPC Server")
 
 	rootCmd.AddCommand(cmdList, cmdInfo)
 	rootCmd.Execute()

--- a/connection_windows.go
+++ b/connection_windows.go
@@ -184,6 +184,23 @@ func (ao *AutomationObject) IsConnected() bool {
 	return true
 }
 
+//GetOPCServers returns a list of Prog ID on the specified node
+func (ao *AutomationObject) GetOPCServers(node string) []string {
+	progids, err := oleutil.CallMethod(ao.object, "GetOPCServers", node)
+	if err != nil {
+		log.Println("GetOPCServers call failed.")
+		return []string{}
+	}
+
+	var servers_found []string
+	for _, v := range progids.ToArray().ToStringArray() {
+		if v != "" {
+			servers_found = append(servers_found, v)
+		}
+	}
+	return servers_found
+}
+
 //Close releases the OLE objects in the AutomationObject.
 func (ao *AutomationObject) Close() {
 	ao.object.Release()


### PR DESCRIPTION
```
Usage:
  opc-cli [command]

Available Commands:
  browse      Browse OPC tags. If only sub-branch is requested, use optional branch_name.
  help        Help about any command
  info        Try connect the OPC server on a specific node and check if it is running.
  list        Lists the OPC servers available on a specific node.
  read        Read OPC tags.
  write       Write value to OPC tag.

Flags:
  -h, --help   help for opc-cli
```