### PR TITLE
fix: resolve the issue of clearing tags with the conn_fix function

### DIFF
--- a/connection_windows.go
+++ b/connection_windows.go
@@ -434,8 +434,8 @@ func (conn *opcConnectionImpl) Tags() []string {
 func (conn *opcConnectionImpl) fix() {
 	var err error
 	if !conn.IsConnected() {
+		tags := conn.Tags()
 		for {
-			tags := conn.Tags()
 			conn.AutomationItems.Close()
 			conn.AutomationItems, err = conn.TryConnect(conn.Server, conn.Nodes)
 			if err != nil {
@@ -494,3 +494,4 @@ func CreateBrowser(server string, nodes []string) (*Tree, error) {
 	}
 	return object.CreateBrowser()
 }
+


### PR DESCRIPTION
在个别点异常后调用fix函数，fix函数多次循环过程中首先使用tags变量对opc连接点位数据进行了存储，随后清空了conn中的点位数据，但当第一次尝试重连无效时，后续又会重新给tags赋值，从而导致数据丢失