### PR TITLE
feat: fix reconnect add empty tags

### DIFF
--- a/connection_windows.go
+++ b/connection_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package opc
 

--- a/connection_windows.go
+++ b/connection_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package opc
@@ -16,24 +17,24 @@ func init() {
 	OleInit()
 }
 
-//OleInit initializes OLE.
+// OleInit initializes OLE.
 func OleInit() {
 	ole.CoInitializeEx(0, 0)
 }
 
-//OleRelease realeses OLE resources in opcAutomation.
+// OleRelease realeses OLE resources in opcAutomation.
 func OleRelease() {
 	ole.CoUninitialize()
 }
 
-//AutomationObject loads the OPC Automation Wrapper and handles to connection to the OPC Server.
+// AutomationObject loads the OPC Automation Wrapper and handles to connection to the OPC Server.
 type AutomationObject struct {
 	unknown *ole.IUnknown
 	object  *ole.IDispatch
 }
 
-//CreateBrowser returns the OPCBrowser object from the OPCServer.
-//It only works if there is a successful connection.
+// CreateBrowser returns the OPCBrowser object from the OPCServer.
+// It only works if there is a successful connection.
 func (ao *AutomationObject) CreateBrowser() (*Tree, error) {
 	// check if server is running, if not return error
 	if !ao.IsConnected() {
@@ -56,7 +57,7 @@ func (ao *AutomationObject) CreateBrowser() (*Tree, error) {
 	return &root, nil
 }
 
-//buildTree runs through the OPCBrowser and creates a tree with the OPC tags
+// buildTree runs through the OPCBrowser and creates a tree with the OPC tags
 func buildTree(browser *ole.IDispatch, branch *Tree) {
 	var count int32
 
@@ -109,8 +110,8 @@ func buildTree(browser *ole.IDispatch, branch *Tree) {
 
 }
 
-//Connect establishes a connection to the OPC Server on node.
-//It returns a reference to AutomationItems and error message.
+// Connect establishes a connection to the OPC Server on node.
+// It returns a reference to AutomationItems and error message.
 func (ao *AutomationObject) Connect(server string, node string) (*AutomationItems, error) {
 
 	// make sure there is not active connection before trying to connect
@@ -149,7 +150,7 @@ func (ao *AutomationObject) Connect(server string, node string) (*AutomationItem
 	return NewAutomationItems(addItemObject.ToIDispatch()), nil
 }
 
-//TryConnect loops over the nodes array and tries to connect to any of the servers.
+// TryConnect loops over the nodes array and tries to connect to any of the servers.
 func (ao *AutomationObject) TryConnect(server string, nodes []string) (*AutomationItems, error) {
 	var errResult string
 	for _, node := range nodes {
@@ -162,7 +163,7 @@ func (ao *AutomationObject) TryConnect(server string, nodes []string) (*Automati
 	return nil, errors.New("TryConnect was not successful: " + errResult)
 }
 
-//IsConnected check if the server is properly connected and up and running.
+// IsConnected check if the server is properly connected and up and running.
 func (ao *AutomationObject) IsConnected() bool {
 	if ao.object == nil {
 		return false
@@ -178,7 +179,7 @@ func (ao *AutomationObject) IsConnected() bool {
 	return true
 }
 
-//GetOPCServers returns a list of Prog ID on the specified node
+// GetOPCServers returns a list of Prog ID on the specified node
 func (ao *AutomationObject) GetOPCServers(node string) []string {
 	progids, err := oleutil.CallMethod(ao.object, "GetOPCServers", node)
 	if err != nil {
@@ -195,7 +196,7 @@ func (ao *AutomationObject) GetOPCServers(node string) []string {
 	return servers_found
 }
 
-//Disconnect checks if connected to server and if so, it calls 'disconnect'
+// Disconnect checks if connected to server and if so, it calls 'disconnect'
 func (ao *AutomationObject) disconnect() {
 	if ao.IsConnected() {
 		_, err := oleutil.CallMethod(ao.object, "Disconnect")
@@ -205,7 +206,7 @@ func (ao *AutomationObject) disconnect() {
 	}
 }
 
-//Close releases the OLE objects in the AutomationObject.
+// Close releases the OLE objects in the AutomationObject.
 func (ao *AutomationObject) Close() {
 	if ao.object != nil {
 		ao.disconnect()
@@ -216,7 +217,7 @@ func (ao *AutomationObject) Close() {
 	}
 }
 
-//NewAutomationObject connects to the COM object based on available wrappers.
+// NewAutomationObject connects to the COM object based on available wrappers.
 func NewAutomationObject() *AutomationObject {
 	// TODO: list should not be hard-coded
 	wrappers := []string{
@@ -250,14 +251,14 @@ func NewAutomationObject() *AutomationObject {
 	return &object
 }
 
-//AutomationItems store the OPCItems from OPCGroup and does the bookkeeping
-//for the individual OPC items. Tags can added, removed, and read.
+// AutomationItems store the OPCItems from OPCGroup and does the bookkeeping
+// for the individual OPC items. Tags can added, removed, and read.
 type AutomationItems struct {
 	addItemObject *ole.IDispatch
 	items         map[string]*ole.IDispatch
 }
 
-//addSingle adds the tag and returns an error. Client handles are not implemented yet.
+// addSingle adds the tag and returns an error. Client handles are not implemented yet.
 func (ai *AutomationItems) addSingle(tag string) error {
 	clientHandle := int32(1)
 	item, err := oleutil.CallMethod(ai.addItemObject, "AddItem", tag, clientHandle)
@@ -268,7 +269,7 @@ func (ai *AutomationItems) addSingle(tag string) error {
 	return nil
 }
 
-//Add accepts a variadic parameters of tags.
+// Add accepts a variadic parameters of tags.
 func (ai *AutomationItems) Add(tags ...string) error {
 	var errResult string
 	for _, tag := range tags {
@@ -283,7 +284,7 @@ func (ai *AutomationItems) Add(tags ...string) error {
 	return errors.New(errResult)
 }
 
-//Remove removes the tag.
+// Remove removes the tag.
 func (ai *AutomationItems) Remove(tag string) {
 	item, ok := ai.items[tag]
 	if ok {
@@ -306,7 +307,7 @@ func ensureInt16(q interface{}) int16 {
 	return 0
 }
 
-//readFromOPC reads from the server and returns an Item and error.
+// readFromOPC reads from the server and returns an Item and error.
 func (ai *AutomationItems) readFromOpc(opcitem *ole.IDispatch) (Item, error) {
 	v := ole.NewVariant(ole.VT_R4, 0)
 	q := ole.NewVariant(ole.VT_INT, 0)
@@ -330,7 +331,7 @@ func (ai *AutomationItems) readFromOpc(opcitem *ole.IDispatch) (Item, error) {
 	}, nil
 }
 
-//writeToOPC writes value to opc tag and return an error
+// writeToOPC writes value to opc tag and return an error
 func (ai *AutomationItems) writeToOpc(opcitem *ole.IDispatch, value interface{}) error {
 	_, err := oleutil.CallMethod(opcitem, "Write", value)
 	if err != nil {
@@ -342,7 +343,7 @@ func (ai *AutomationItems) writeToOpc(opcitem *ole.IDispatch, value interface{})
 	return nil
 }
 
-//Close closes the OLE objects in AutomationItems.
+// Close closes the OLE objects in AutomationItems.
 func (ai *AutomationItems) Close() {
 	if ai != nil {
 		for key, opcitem := range ai.items {
@@ -353,15 +354,15 @@ func (ai *AutomationItems) Close() {
 	}
 }
 
-//NewAutomationItems returns a new AutomationItems instance.
+// NewAutomationItems returns a new AutomationItems instance.
 func NewAutomationItems(opcitems *ole.IDispatch) *AutomationItems {
 	ai := AutomationItems{addItemObject: opcitems, items: make(map[string]*ole.IDispatch)}
 	return &ai
 }
 
-//opcRealServer implements the Connection interface.
-//It has the AutomationObject embedded for connecting to the server
-//and an AutomationItems to facilitate the OPC items bookkeeping.
+// opcRealServer implements the Connection interface.
+// It has the AutomationObject embedded for connecting to the server
+// and an AutomationItems to facilitate the OPC items bookkeeping.
 type opcConnectionImpl struct {
 	*AutomationObject
 	*AutomationItems
@@ -370,7 +371,7 @@ type opcConnectionImpl struct {
 	mu     sync.Mutex
 }
 
-//ReadItem returns an Item for a specific tag.
+// ReadItem returns an Item for a specific tag.
 func (conn *opcConnectionImpl) ReadItem(tag string) Item {
 	conn.mu.Lock()
 	defer conn.mu.Unlock()
@@ -388,7 +389,7 @@ func (conn *opcConnectionImpl) ReadItem(tag string) Item {
 	return Item{}
 }
 
-//Write writes a value to the OPC Server.
+// Write writes a value to the OPC Server.
 func (conn *opcConnectionImpl) Write(tag string, value interface{}) error {
 	conn.mu.Lock()
 	defer conn.mu.Unlock()
@@ -400,7 +401,7 @@ func (conn *opcConnectionImpl) Write(tag string, value interface{}) error {
 	return errors.New("No Write performed")
 }
 
-//Read returns a map of the values of all added tags.
+// Read returns a map of the values of all added tags.
 func (conn *opcConnectionImpl) Read() map[string]Item {
 	conn.mu.Lock()
 	defer conn.mu.Unlock()
@@ -417,7 +418,7 @@ func (conn *opcConnectionImpl) Read() map[string]Item {
 	return allTags
 }
 
-//Tags returns the currently active tags
+// Tags returns the currently active tags
 func (conn *opcConnectionImpl) Tags() []string {
 	var tags []string
 	if conn.AutomationItems != nil {
@@ -429,14 +430,14 @@ func (conn *opcConnectionImpl) Tags() []string {
 
 }
 
-//fix tries to reconnect if connection is lost by creating a new connection
-//with AutomationObject and creating a new AutomationItems instance.
+// fix tries to reconnect if connection is lost by creating a new connection
+// with AutomationObject and creating a new AutomationItems instance.
 func (conn *opcConnectionImpl) fix() {
 	var err error
 	if !conn.IsConnected() {
+		tags := conn.Tags()
+		conn.AutomationItems.Close()
 		for {
-			tags := conn.Tags()
-			conn.AutomationItems.Close()
 			conn.AutomationItems, err = conn.TryConnect(conn.Server, conn.Nodes)
 			if err != nil {
 				logger.Println(err)
@@ -451,7 +452,7 @@ func (conn *opcConnectionImpl) fix() {
 	}
 }
 
-//Close closes the embedded types.
+// Close closes the embedded types.
 func (conn *opcConnectionImpl) Close() {
 	conn.mu.Lock()
 	defer conn.mu.Unlock()
@@ -463,7 +464,7 @@ func (conn *opcConnectionImpl) Close() {
 	}
 }
 
-//NewConnection establishes a connection to the OpcServer object.
+// NewConnection establishes a connection to the OpcServer object.
 func NewConnection(server string, nodes []string, tags []string) (Connection, error) {
 	object := NewAutomationObject()
 	items, err := object.TryConnect(server, nodes)
@@ -484,7 +485,7 @@ func NewConnection(server string, nodes []string, tags []string) (Connection, er
 	return &conn, nil
 }
 
-//CreateBrowser creates an opc browser representation
+// CreateBrowser creates an opc browser representation
 func CreateBrowser(server string, nodes []string) (*Tree, error) {
 	object := NewAutomationObject()
 	defer object.Close()


### PR DESCRIPTION
When the network is unstable, it may trigger a reconnect. If it reconnects more than once, the previous tag records get cleared, so after reconnecting, the preivous tags can't be read.
code change just see line 438 and 439